### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/MoveInSync Assignment/api/routes/user.js
+++ b/MoveInSync Assignment/api/routes/user.js
@@ -3,9 +3,18 @@ const router = express.Router();
 const mongoose = require("mongoose");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+const rateLimit = require("express-rate-limit");
 
 const User = require("../models/user");
 
+// Rate limiter for login route (e.g. max 5 requests per 10 minutes per IP)
+const loginLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 5, // Limit each IP to 5 requests per windowMs
+  message: {
+    message: "Too many login attempts from this IP, please try again later."
+  }
+});
 router.post("/signup", (req, res, next) => {
   User.find({ username : req.body.username })
     .exec()
@@ -59,7 +68,7 @@ router.post("/signup", (req, res, next) => {
 });
 
 
-router.post("/login", (req, res, next) => {
+router.post("/login", loginLimiter, (req, res, next) => {
   User.find({ username : req.body.username }) 
     .exec()
     .then((user) => {

--- a/MoveInSync Assignment/package.json
+++ b/MoveInSync Assignment/package.json
@@ -20,7 +20,8 @@
     "mongoose": "^6.3.3",
     "morgan": "^1.10.0",
     "multer": "^1.4.4",
-    "passport-local-mongoose": "^7.1.2"
+    "passport-local-mongoose": "^7.1.2",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"


### PR DESCRIPTION
Potential fix for [https://github.com/Standby-Coder/RidePool/security/code-scanning/5](https://github.com/Standby-Coder/RidePool/security/code-scanning/5)

To fix the problem, a rate-limiting middleware should be added to the `/login` route to limit the number of requests from any single IP address within a given time window, reducing the risk of brute-force attacks and denial-of-service via repeated login attempts. The best approach is to use the well-known `express-rate-limit` package.

Specifically:
- Import the `express-rate-limit` package at the top of the file.
- Define a rate limiter instance (e.g., for `/login`, something more restrictive like 5 attempts per 10 minutes).
- Apply the rate-limiter middleware to the `/login` route.
The code for other routes should not be affected; only the `/login` route is modified unless other sensitive endpoints warrant similar protection.

Changes needed:
- Imports: Add `express-rate-limit`.
- Code edits: Add rate limiter definition.
- Apply the rate limiter as middleware for the `/login` route.
